### PR TITLE
Support building with non-default java toolchain.

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_java_library.bzl
+++ b/build_defs/internal_do_not_use/j2cl_java_library.bzl
@@ -102,7 +102,7 @@ _J2CL_LIB_ATTRS = {
     "javacopts": attr.string_list(),
     "licenses": attr.license(),
     "_java_toolchain": attr.label(
-        default = Label("@bazel_tools//tools/jdk:toolchain"),
+        default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
     ),
     "_host_javabase": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),


### PR DESCRIPTION
See https://issuetracker.google.com/issues/122629756

This is particularly valuable to allow developers to build with JDK8