### PR TITLE
Support the workflow under Windows. #9

### DIFF
--- a/transpiler/java/com/google/j2cl/generator/OutputGeneratorStage.java
+++ b/transpiler/java/com/google/j2cl/generator/OutputGeneratorStage.java
@@ -279,13 +279,13 @@ public class OutputGeneratorStage {
     TypeDeclaration typeDeclaration = type.getDeclaration();
     String typeName = typeDeclaration.getSimpleBinaryName();
     String packageName = typeDeclaration.getPackageName();
-    return packageName.replace(".", File.separator) + File.separator + typeName;
+    return packageName.replace(".", "/") + '/' + typeName;
   }
 
   /** Returns the absolute binary path for a given type. */
   private static String getAbsolutePath(CompilationUnit compilationUnit, Type type) {
     TypeDeclaration typeDeclaration = type.getDeclaration();
     String typeName = typeDeclaration.getSimpleBinaryName();
-    return compilationUnit.getDirectoryPath() + File.separator + typeName;
+    return compilationUnit.getDirectoryPath() + '/' + typeName;
   }
 }


### PR DESCRIPTION
I found and fixed the first file/path issue, while running j2cl native with Windows 10 ... added the following fix ".replace('\\', '/')" here "com.google.j2cl.generator.OutputGeneratorStage#generateOutputs:87"

String typeRelativePath = getRelativePath(type).replace('\\', '/');

Not sure if this fix is well placed, but is corrects the issue (looking up an windows path in a map with unix paths)...