### PR TITLE
Allow compiling in WHITESPACE mode

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_js_common.bzl
+++ b/build_defs/internal_do_not_use/j2cl_js_common.bzl
@@ -9,6 +9,7 @@ def j2cl_js_provider(ctx, srcs = [], deps = [], exports = []):
       "analyzerChecks",
       "JSC_UNKNOWN_EXPR_TYPE",
       "JSC_STRICT_INEXISTENT_PROPERTY",
+      "unusedLocalVariables",
     ]
     suppresses = default_j2cl_suppresses + ctx.attr.js_suppress
 


### PR DESCRIPTION
We're using WHITESPACE instead of BUNDLE because bundle doesn't support source maps.
(That doesn't fix source maps for j2cl code, but at least source maps for non-j2cl code still works)