### PR TITLE
Ensure all javascript flows from jars through to transpiler

### DIFF
--- a/tools/java/com/google/j2cl/tools/gwtincompatible/GwtIncompatibleStripper.java
+++ b/tools/java/com/google/j2cl/tools/gwtincompatible/GwtIncompatibleStripper.java
@@ -34,7 +34,7 @@ public class GwtIncompatibleStripper {
       FileSystem outputZipFileSystem = FrontendUtils.initZipOutput(outputPath, problems);
       List<FileInfo> allPaths =
           FrontendUtils.getAllSources(files, problems)
-              .filter(f -> f.targetPath().endsWith(".java"))
+              .filter(f -> f.targetPath().endsWith(".java") || f.targetPath().endsWith(".js"))
               .collect(ImmutableList.toImmutableList());
       JavaPreprocessor.preprocessFiles(allPaths, outputZipFileSystem.getPath("/"), problems);
 

--- a/tools/java/com/google/j2cl/tools/gwtincompatible/JavaPreprocessor.java
+++ b/tools/java/com/google/j2cl/tools/gwtincompatible/JavaPreprocessor.java
@@ -51,7 +51,7 @@ public class JavaPreprocessor {
       try {
         String fileContent =
             MoreFiles.asCharSource(Paths.get(fileInfo.sourcePath()), StandardCharsets.UTF_8).read();
-        processedFileContent = processFile(fileContent);
+        processedFileContent = fileInfo.targetPath().endsWith(".java") ? processFile(fileContent) : fileContent;
       } catch (IOException e) {
         problems.fatal(FatalError.CANNOT_OPEN_FILE, e.toString());
         return;

--- a/transpiler/java/com/google/j2cl/transpiler/J2clCommandLineRunner.java
+++ b/transpiler/java/com/google/j2cl/transpiler/J2clCommandLineRunner.java
@@ -103,7 +103,7 @@ public final class J2clCommandLineRunner extends CommandLineTool {
                 .collect(ImmutableList.toImmutableList()))
         .setNativeSources(
             FrontendUtils.getAllSources(getPathEntries(this.nativeSourcePath), problems)
-                .filter(p -> p.sourcePath().endsWith(".native.js"))
+                .filter(p -> p.sourcePath().endsWith(".js"))
                 .collect(ImmutableList.toImmutableList()))
         .setClasspaths(getPathEntries(this.classPath))
         .setOutput(


### PR DESCRIPTION
Note: This PR is not meant for merging (has no tests yet) but is meant to provoke a discussion.

Outside of Google I expect most people will retrieve libraries from a binary artifact repository (ala Maven central). In an ideal world, this archive is going to contain a combination of `.java` files, `.native.js` files, `.extern.js` files and probably some random `.js` modules.

An example where this would make sense is in [react4j-core](https://github.com/react4j/react4j/tree/master/core/src/main/java/react4j) artifact that includes [ReactConfig.native.js](https://github.com/react4j/react4j/blob/master/core/src/main/java/react4j/ReactConfig.native.js) which loads a js module [react4j.js](https://github.com/react4j/react4j/blob/master/core/src/main/java/react4j/react4j.js) that essentially contains a bunch of `goog.define(...)` expressions/statements. It also includes [react.externs.js](https://github.com/react4j/react4j/blob/master/core/src/main/java/react4j/react.externs.js) for defining externs and the actually external code as well.

ATM the moment this does not work as the `GwtIncompatibleStripper` will create a new src file that only contains `.java` files. Even if it includes all the `.js` files, the transpiler only packages `.native.js` files.

When @niloc132 initially created his maven dev tools on top of J2CL, he included all js in the jar in the compilation phase. So this changeset follows that model. The advantage of this approach is that it is nice and simple to implement and reasonably easy for users to understand. (i.e. Include js in jar and it gets put into the compiler). Combining this together with [bazelbuild/rules_jvm_external](https://github.com/bazelbuild/rules_jvm_external) has made it reasonably easy to put together a few example apps built using this technique.

The weakness of the approach is that sometimes you don't want the non-closure modules included by default. i.e currently `react4j-core` ships with 3 variants of UMD react.js modules (one development, one profiler, one production) and GWT2.x select the javascript assets they want based on the GWT modules inherited from. 

To achieve the same under J2CL I would need potentially 4 separate maven artifacts `react4j-core`, `react4j-core-dev`, `react4j-core-prod`, `react4j-core-profile` or a single artifact with a descriptor (in jar manifest, xml, or json config) that declared the optional assets and which closure defines would be required to include which assets.  Using a descriptor is more complex but would cover off all the use cases I have come across.

Another thing to note is that currently closure compiler only supports modules that are google modules, ES6 modules with partial support for CommonJS/JSON modules. I expect it will eventually support some of the more other module types coming into play.

Thoughts?







