### PR TITLE
Specify sha256 hashs for external repositories

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_workspace.bzl
+++ b/build_defs/internal_do_not_use/j2cl_workspace.bzl
@@ -151,6 +151,7 @@ def setup_j2cl_workspace():
         name = "com_google_protobuf",
         strip_prefix = "protobuf-3.6.1.3",
         urls = ["https://github.com/google/protobuf/archive/v3.6.1.3.zip"],
+        sha256 = "9510dd2afc29e7245e9e884336f848c8a6600a14ae726adb6befdb4f786f0be2",
     )
 
     # needed for protobuf

--- a/build_defs/repository.bzl
+++ b/build_defs/repository.bzl
@@ -13,9 +13,11 @@ def load_j2cl_repo_deps():
         name = "bazel_skylib",
         repo = "bazelbuild/bazel-skylib",
         tag = "0.7.0",
+        sha256 = "bce240a0749dfc52fab20dce400b4d5cf7c28b239d64f8fd1762b3c9470121d8",
+
     )
 
-def _github_repo(name, repo, tag):
+def _github_repo(name, repo, tag, sha256 = None):
     if native.existing_rule(name):
         return
 
@@ -24,4 +26,5 @@ def _github_repo(name, repo, tag):
         name = name,
         strip_prefix = "%s-%s" % (project_name, tag),
         url = "https://github.com/%s/archive/%s.zip" % (repo, tag),
+        sha256 = sha256,
     )


### PR DESCRIPTION
For artifacts with specific versions, the hash encourages caching