### PR TITLE
Remove attr.license() call

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_java_library.bzl
+++ b/build_defs/internal_do_not_use/j2cl_java_library.bzl
@@ -63,7 +63,6 @@ _J2CL_LIB_ATTRS = {
     "plugins": attr.label_list(providers = [JavaInfo]),
     "exported_plugins": attr.label_list(providers = [JavaInfo]),
     "javacopts": attr.string_list(),
-    "licenses": attr.license(),
 }
 _J2CL_LIB_ATTRS.update(_J2CL_INTERNAL_LIB_ATTRS)
 _J2CL_LIB_ATTRS.update(J2CL_TOOLCHAIN_ATTRS)
@@ -94,7 +93,6 @@ def _impl_java_import(ctx):
 
 _J2CL_IMPORT_ATTRS = {
     "jar": attr.label(providers = [JavaInfo]),
-    "licenses": attr.license(),
 }
 _J2CL_IMPORT_ATTRS.update(J2CL_TOOLCHAIN_ATTRS)
 


### PR DESCRIPTION
Fixes the following errors:

`ERROR: com_google_j2cl/build_defs/internal_do_not_use/j2cl_java_library.bzl:66:17: type 'attr (a language module)' has no method license()`
`ERROR: com_google_j2cl/build_defs/internal_do_not_use/j2cl_java_library.bzl:68:1: global variable '_J2CL_LIB_ATTRS' is referenced before assignment.
`
...

Bazel version: 0.25.3