### PR TITLE
Allow rules of type java_library in plugins label list

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_java_library.bzl
+++ b/build_defs/internal_do_not_use/j2cl_java_library.bzl
@@ -60,7 +60,7 @@ _J2CL_LIB_ATTRS = {
     "srcs": attr.label_list(allow_files = [".java", ".js", ".srcjar", ".jar", ".zip"]),
     "deps": attr.label_list(providers = [JS_PROVIDER_NAME]),
     "exports": attr.label_list(providers = [JS_PROVIDER_NAME]),
-    "plugins": attr.label_list(allow_rules = ["java_plugin"], cfg = "host"),
+    "plugins": attr.label_list(allow_rules = ["java_library","java_plugin"], cfg = "host"),
     "exported_plugins": attr.label_list(allow_rules = ["java_plugin"], cfg = "host"),
     "javacopts": attr.string_list(),
 }


### PR DESCRIPTION
It is not uncommon to define a java_library that aggregates several
java_plugin rules and then exports them via exported_plugins. This
change supports using these libraries as plugins for j2cl_library rule
and is consistent with the behaviour of java_library's usage of
the plugin attribute.