### PR TITLE
Force the use of UTF-8 when writing to disk, and correct typo when reading

### DIFF
--- a/transpiler/java/com/google/j2cl/common/J2clUtils.java
+++ b/transpiler/java/com/google/j2cl/common/J2clUtils.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.FileTime;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.function.Consumer;
 import org.apache.commons.text.StringEscapeUtils;
 
@@ -60,7 +60,7 @@ public class J2clUtils {
   public static void writeToFile(Path outputPath, String content, Problems problems) {
     try {
       createDirectories(outputPath.getParent());
-      Files.write(outputPath, Arrays.asList(content));
+      Files.write(outputPath, Collections.singleton(content), StandardCharsets.UTF_8);
       // Wipe entries modification time so that input->output mapping is stable
       // regardless of the time of day.
       maybeResetAllTimeStamps(outputPath);

--- a/transpiler/java/com/google/j2cl/frontend/jdt/JdtParser.java
+++ b/transpiler/java/com/google/j2cl/frontend/jdt/JdtParser.java
@@ -21,6 +21,7 @@ import com.google.j2cl.common.FrontendUtils.FileInfo;
 import com.google.j2cl.common.Problems;
 import com.google.j2cl.common.Problems.FatalError;
 import com.google.j2cl.frontend.common.FrontendConstants;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -116,7 +117,7 @@ public class JdtParser {
 
   private String[] getEncodings(int length) {
     String[] encodings = new String[length];
-    Arrays.fill(encodings, "UTF_8");
+    Arrays.fill(encodings, StandardCharsets.UTF_8.name());
     return encodings;
   }
 


### PR DESCRIPTION
When reading, the charset was incorrectly `"UTF_8"` when it should have been `"UTF-8"` - my change uses the StandardCharsets constant to avoid possible typos.

Also using a singleton collection rather than Arrays.asList varargs array.