### PR TITLE
Allow sources to come from any jar

### DIFF
--- a/tools/java/com/google/j2cl/tools/gwtincompatible/GwtIncompatibleStripperCommandLineRunner.java
+++ b/tools/java/com/google/j2cl/tools/gwtincompatible/GwtIncompatibleStripperCommandLineRunner.java
@@ -40,7 +40,7 @@ final class GwtIncompatibleStripperCommandLineRunner extends CommandLineTool {
 
   @Override
   protected Problems run() {
-    checkSourceFiles(files, ".java", ".srcjar", "-src.jar");
+    checkSourceFiles(files, ".java", ".srcjar", ".jar");
     return GwtIncompatibleStripper.strip(files, outputPath);
   }
 

--- a/transpiler/java/com/google/j2cl/transpiler/J2clCommandLineRunner.java
+++ b/transpiler/java/com/google/j2cl/transpiler/J2clCommandLineRunner.java
@@ -89,7 +89,7 @@ public final class J2clCommandLineRunner extends CommandLineTool {
   }
 
   private J2clTranspilerOptions createOptions() {
-    checkSourceFiles(files, ".java", ".srcjar", "-src.jar");
+    checkSourceFiles(files, ".java", ".srcjar", ".jar");
 
     Problems problems = new Problems();
     if (this.readableSourceMaps && this.generateKytheIndexingMetadata) {


### PR DESCRIPTION
Conventions vary between build tools as to what they call their source jars, and sometimes they are just plain jars. This change allows any .jar file to be allowed as a way to provide source files.

While downstream tooling could certainly copy and rename every jar before it is transpiled or forbid zip/jar files outside of bazel, this seems excessive since the wiring is already there to handle these cases, just need the validation to be looser.