### PR TITLE
Allow output to be generated in directories that don't exist yet

### DIFF
--- a/transpiler/java/com/google/j2cl/common/FrontendUtils.java
+++ b/transpiler/java/com/google/j2cl/common/FrontendUtils.java
@@ -156,6 +156,7 @@ public class FrontendUtils {
 
     // Ensures that we will not fail if the zip already exists.
     outputPath.toFile().delete();
+    outputPath.toFile().getParentFile().mkdirs();
 
     try {
       return FileSystems.newFileSystem(


### PR DESCRIPTION
The previous line here ensures that the output zip does not exist (and is unconcerned if it didn't exist to begin with), but no check is made if the parent directory (or directories) exists. This patch helps when invoking a j2cl tool and pointing to an output path which doesn't yet exist.

Probably will be a moot point when the gwtincompatiblestripper doesn't require creating a zip file.