### PR TITLE
Make junit_processor generate proper JSON

### DIFF
--- a/junit/generator/java/com/google/j2cl/junit/apt/TemplateWriter.java
+++ b/junit/generator/java/com/google/j2cl/junit/apt/TemplateWriter.java
@@ -49,7 +49,7 @@ class TemplateWriter {
     try {
       writeResource(
           "test_summary.json",
-          testSummary.stream().collect(Collectors.joining("','", "{'tests': ['", "']}")));
+          testSummary.stream().collect(Collectors.joining("\",\"", "{\"tests\": [\"", "\"]}")));
     } catch (Exception e) {
       errorReporter.report(ErrorMessage.CANNOT_WRITE_RESOURCE, exceptionToString(e));
     }


### PR DESCRIPTION
Strings in JSON are double-quoted, not single-quoted.