### PR TITLE
Remove the java root prefix from GwtIncompatibleStripper output

### DIFF
--- a/tools/java/com/google/j2cl/tools/gwtincompatible/GwtIncompatibleStripper.java
+++ b/tools/java/com/google/j2cl/tools/gwtincompatible/GwtIncompatibleStripper.java
@@ -81,7 +81,7 @@ public final class GwtIncompatibleStripper {
 
       // Write the processed file to output
       J2clUtils.writeToFile(
-          output.resolve(fileInfo.originalPath()), processedFileContent, problems);
+          output.resolve(fileInfo.targetPath()), processedFileContent, problems);
     }
   }
 


### PR DESCRIPTION
According to https://github.com/google/j2cl/issues/98#issuecomment-659101173
that's the intended behavior.