### PR TITLE
Bump google auto-common to 1.1.2

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_workspace.bzl
+++ b/build_defs/internal_do_not_use/j2cl_workspace.bzl
@@ -19,10 +19,10 @@ def setup_j2cl_workspace(**kwargs):
 
     jvm_maven_import_external(
         name = "com_google_auto_common",
-        artifact = "com.google.auto:auto-common:0.9",
+        artifact = "com.google.auto:auto-common:1.1.2",
         server_urls = _MAVEN_CENTRAL_URLS,
         licenses = ["notice"],
-        artifact_sha256 = "d65d7e7b45ac92317eae8a55481ca25e5fba908a2fd24b66684854d9dec2fcfd",
+        artifact_sha256 = "bfe85e517250fc208afd2b031a2ba80f26529c92536484841b4a60661ca1e3f5",
     )
 
     jvm_maven_import_external(


### PR DESCRIPTION
`auto-common` should be upgraded to fix build since https://github.com/google/j2cl/commit/2bfdbd58f9525d009e8041b4a3e1ec76bda9f0d6. Without upgrade build fails with:
```
junit/generator/java/com/google/j2cl/junit/apt/MoreApt.java:91: error: method toString in class Object cannot be applied to given types;
        .map(input -> extractClassName(AnnotationValues.toString(input)))
                                                       ^
  required: no arguments
  found: AnnotationValue
  reason: actual and formal argument lists differ in length
junit/generator/java/com/google/j2cl/junit/apt/MoreApt.java:92: error: incompatible types: inference variable E has incompatible bounds
        .collect(toImmutableList());
                ^
    equality constraints: String
    lower bounds: Object
  where E is a type-variable:
    E extends Object declared in method <E>toImmutableList()
junit/generator/java/com/google/j2cl/junit/apt/MoreApt.java:106: error: method toString in class Object cannot be applied to given types;
      return Optional.of(extractClassName(AnnotationValues.toString(annotationValue.get())));
                                                          ^
  required: no arguments
  found: AnnotationValue
  reason: actual and formal argument lists differ in length
```