### PR TITLE
Pass host:port down to web_library for dev server

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_application.bzl
+++ b/build_defs/internal_do_not_use/j2cl_application.bzl
@@ -6,6 +6,8 @@ def j2cl_application(
         name,
         entry_points,
         deps,
+        host = "0.0.0.0",
+        port = "6006",
         rewrite_polyfills = False,
         jre_logging_log_level = "OFF",
         jre_checks_check_level = "NORMAL",
@@ -141,6 +143,8 @@ loadScript(`$${appName}_dev.js`);
         name = "%s_dev" % name,
         entry_point_defs = entry_point_defs,
         deps = deps,
+        host = host,
+        port = port,
         dev_resources = dev_resources,
         **kwargs
     )

--- a/build_defs/internal_do_not_use/j2cl_js_common.bzl
+++ b/build_defs/internal_do_not_use/j2cl_js_common.bzl
@@ -45,6 +45,8 @@ def js_devserver(
         entry_point_defs,
         deps,
         dev_resources,
+        host ="0.0.0.0",
+        port = "6006",
         **kwargs):
     """Creates a development server target."""
 
@@ -63,6 +65,8 @@ def js_devserver(
         name = "%s_server" % name,
         srcs = dev_resources,
         path = "/",
+        host = host,
+        port = port,
         tags = [
             "ibazel_live_reload",  # Enable ibazel reload server.
             "ibazel_notify_changes",  # Do not to restart the server on changes.

--- a/build_defs/repository.bzl
+++ b/build_defs/repository.bzl
@@ -16,8 +16,8 @@ def load_j2cl_repo_deps():
     _github_repo(
         name = "io_bazel_rules_closure",
         repo = "bazelbuild/rules_closure",
-        tag = "1d8c08055488d15c4eaa7e70f9bdfba1b2c83b5b",
-        sha256 = "6032db43d2ce09570a0de94b3a2b5e24654a9232c45e0d418b5314867adf4173",
+        tag = "c73467788b977172d5022f6a8125f616999f5a74",
+        sha256 = "06e07b812118a72aced71f49471eac8b9d9c09ad31da56d340164ee9d78d7284",
     )
 
     _github_repo(


### PR DESCRIPTION
Example usage in wasm sample:

j2cl_application(
    name = "jsapp",
    ...
    host = "0.0.0.0",
    port = "8080",
)

I don't know if I'm doing this right, so please advise (or just close and someone who knows what they are doing can take over).