### PR TITLE
Allow users to bypass J2CL's default Kotlin repositories

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_workspace.bzl
+++ b/build_defs/internal_do_not_use/j2cl_workspace.bzl
@@ -8,7 +8,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_reg
 
 _MAVEN_CENTRAL_URLS = ["https://repo1.maven.org/maven2/"]
 
-def setup_j2cl_workspace(**kwargs):
+def setup_j2cl_workspace(omit_kotlin = False, **kwargs):
     """Load all dependencies needed for J2CL."""
 
     versions.check("5.1.0")  # The version J2CL currently have a CI setup for.
@@ -242,15 +242,16 @@ j2cl_library(
 ''',
     )
 
-    kotlin_repositories(
-        compiler_release = {
-            "urls": [
-                "https://github.com/JetBrains/kotlin/releases/download/v1.6.10/kotlin-compiler-1.6.10.zip",
-            ],
-            "sha256": "432267996d0d6b4b17ca8de0f878e44d4a099b7e9f1587a98edc4d27e76c215a",
-        },
-    )
-    kt_register_toolchains()
+    if not omit_kotlin:
+        kotlin_repositories(
+            compiler_release = {
+                "urls": [
+                    "https://github.com/JetBrains/kotlin/releases/download/v1.6.10/kotlin-compiler-1.6.10.zip",
+                ],
+                "sha256": "432267996d0d6b4b17ca8de0f878e44d4a099b7e9f1587a98edc4d27e76c215a",
+            },
+        )
+        kt_register_toolchains()
 
     # Required by protobuf_java_util
     native.bind(


### PR DESCRIPTION
This enables users to specify newer (or older) Kotlin versions without changes in J2CL.