### PR TITLE
No int that doesn't fit in a char can be whitespace

### DIFF
--- a/jre/java/java/lang/Character.java
+++ b/jre/java/java/lang/Character.java
@@ -311,6 +311,9 @@ public final class Character implements Comparable<Character>, Serializable {
   }
 
   public static boolean isWhitespace(int codePoint) {
+    if (!isValidCodePoint(codePoint)) {
+      return false;
+    }
     return isWhitespace(String.fromCodePoint(codePoint));
   }
 

--- a/jre/javatests/com/google/j2cl/jre/java/lang/CharacterTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java/lang/CharacterTest.java
@@ -395,6 +395,13 @@ public class CharacterTest extends GWTTestCase {
         0x29D98, // UNICODE HAN CHARACTER 'a general name for perch, etc.'.
     };
 
+    int[] otherNonWhitespaceInts = {
+        Character.MAX_VALUE + 1,
+        Character.MAX_CODE_POINT + 1,
+        Integer.MAX_VALUE,
+        -1
+    };
+
     // Must match unicode space separator characters.
     for (char c : separators) {
       assertTrue(Character.isWhitespace(c));
@@ -421,6 +428,11 @@ public class CharacterTest extends GWTTestCase {
 
     // Support for non-UCS-2 characters.
     for (int c : supplementaryCounterExamples) {
+      assertFalse(Character.isWhitespace(c));
+    }
+
+    // Test other valid ints
+    for (int c : otherNonWhitespaceInts) {
       assertFalse(Character.isWhitespace(c));
     }
   }


### PR DESCRIPTION
Test those directly and return false instead of throwing.

Please note that these unit tests have not been run, but the test cases have been manually verified.

Fixes #171