### PR TITLE
 Add Dependabot to update GitHub Actions in CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes #217.

This PR adds dependabot to keep GitHub Actions up-to-date. A single monthly PR will update all Actions with new versions.

Regardless of whether you merge this PR, I recommend you enable [Dependabot Security Updates](https://github.com/google/j2cl/settings/security_analysis) to make sure you get "out-of-season" PRs whenever a vulnerability is found in a dependency.