### PR TITLE
Add support for @JsExport annotation

### DIFF
--- a/transpiler/java/com/google/j2cl/transpiler/ast/JsInfo.java
+++ b/transpiler/java/com/google/j2cl/transpiler/ast/JsInfo.java
@@ -42,6 +42,8 @@ public abstract class JsInfo {
 
   public abstract boolean isJsAsync();
 
+  public abstract boolean isJsExport();
+
   /**
    * Returns true if the JsInfo where computed from a JsInterop annotation defined explicitly on the
    * member.
@@ -72,6 +74,7 @@ public abstract class JsInfo {
         // Default values.
         .setJsOverlay(false)
         .setJsAsync(false)
+        .setJsExport(false)
         .setHasJsMemberAnnotation(false);
   }
 
@@ -88,6 +91,8 @@ public abstract class JsInfo {
     public abstract Builder setJsOverlay(boolean isJsOverlay);
 
     public abstract Builder setJsAsync(boolean isJsAsync);
+
+    public abstract Builder setJsExport(boolean isJsExport);
 
     public abstract Builder setHasJsMemberAnnotation(boolean hasJsMemberAnnotation);
 

--- a/transpiler/java/com/google/j2cl/transpiler/ast/Type.java
+++ b/transpiler/java/com/google/j2cl/transpiler/ast/Type.java
@@ -120,6 +120,10 @@ public class Type extends Node implements HasSourcePosition, HasJsNameInfo, HasR
     return typeDeclaration.isJsEnum();
   }
 
+  public boolean isJsExport() {
+    return typeDeclaration.isAnnotatedWithJsExport();
+  }
+
   public boolean isJsFunctionInterface() {
     return typeDeclaration.isJsFunctionInterface();
   }

--- a/transpiler/java/com/google/j2cl/transpiler/ast/TypeDeclaration.java
+++ b/transpiler/java/com/google/j2cl/transpiler/ast/TypeDeclaration.java
@@ -278,6 +278,9 @@ public abstract class TypeDeclaration
   /** Returns whether the described type has the JUnit @RunWith annotation. */
   public abstract boolean isAnnotatedWithJUnitRunWith();
 
+  /** Returns whether the described type has the "JsExport" annotation. */
+  public abstract boolean isAnnotatedWithJsExport();
+
   @Memoized
   public boolean isJsFunctionImplementation() {
     return isClass()
@@ -791,6 +794,7 @@ public abstract class TypeDeclaration
         .setAnnotatedWithAutoValue(false)
         .setAnnotatedWithAutoValueBuilder(false)
         .setAnnotatedWithJUnitRunWith(false)
+        .setAnnotatedWithJsExport(false)
         .setJsFunctionInterface(false)
         .setJsType(false)
         .setLocal(false)
@@ -854,6 +858,8 @@ public abstract class TypeDeclaration
     public abstract Builder setAnnotatedWithAutoValueBuilder(boolean annotatedWithAutoValueBuilder);
 
     public abstract Builder setAnnotatedWithJUnitRunWith(boolean annotatedWithJUnitRunWith);
+
+    public abstract Builder setAnnotatedWithJsExport(boolean annotatedWithJsExport);
 
     public abstract Builder setJsFunctionInterface(boolean isJsFunctionInterface);
 

--- a/transpiler/java/com/google/j2cl/transpiler/frontend/common/FrontendConstants.java
+++ b/transpiler/java/com/google/j2cl/transpiler/frontend/common/FrontendConstants.java
@@ -47,5 +47,8 @@ public final class FrontendConstants {
   public static final String DO_NOT_AUTOBOX_ANNOTATION_NAME =
       "javaemul.internal.annotations.DoNotAutobox";
 
+  public static final String JS_EXPORT_ANNOTATION_NAME =
+      "com.kohlschutter.jacline.annotations.JsExport";
+
   private FrontendConstants() {}
 }

--- a/transpiler/java/com/google/j2cl/transpiler/frontend/jdt/JdtEnvironment.java
+++ b/transpiler/java/com/google/j2cl/transpiler/frontend/jdt/JdtEnvironment.java
@@ -1203,6 +1203,7 @@ public class JdtEnvironment {
             .setAnnotatedWithAutoValue(isAnnotatedWithAutoValue(typeBinding))
             .setAnnotatedWithAutoValueBuilder(isAnnotatedWithAutoValueBuilder(typeBinding))
             .setAnnotatedWithJUnitRunWith(isAnnotatedWithJUnitRunWith(typeBinding))
+            .setAnnotatedWithJsExport(JsInteropAnnotationUtils.isJsExport(typeBinding))
             .setJsType(JsInteropUtils.isJsType(typeBinding))
             .setJsEnumInfo(JsInteropUtils.getJsEnumInfo(typeBinding))
             .setWasmInfo(getWasmInfo(typeBinding))

--- a/transpiler/java/com/google/j2cl/transpiler/frontend/jdt/JsInteropAnnotationUtils.java
+++ b/transpiler/java/com/google/j2cl/transpiler/frontend/jdt/JsInteropAnnotationUtils.java
@@ -19,6 +19,7 @@ import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.DO_NO
 import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.JS_ASYNC_ANNOTATION_NAME;
 import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.JS_CONSTRUCTOR_ANNOTATION_NAME;
 import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.JS_ENUM_ANNOTATION_NAME;
+import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.JS_EXPORT_ANNOTATION_NAME;
 import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.JS_FUNCTION_ANNOTATION_NAME;
 import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.JS_IGNORE_ANNOTATION_NAME;
 import static com.google.j2cl.transpiler.frontend.common.FrontendConstants.JS_METHOD_ANNOTATION_NAME;
@@ -34,6 +35,7 @@ import static java.util.Arrays.stream;
 import java.util.Optional;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
@@ -99,9 +101,18 @@ public class JsInteropAnnotationUtils {
         methodBinding.getAnnotations(), JS_OVERLAY_ANNOTATION_NAME);
   }
 
+  public static IAnnotationBinding getJsExportAnnotation(IBinding methodOrTypeBinding) {
+    return JdtAnnotationUtils.findAnnotationBindingByName(
+        methodOrTypeBinding.getAnnotations(), JS_EXPORT_ANNOTATION_NAME);
+  }
+
   public static IAnnotationBinding getJsPackageAnnotation(ITypeBinding packageBinding) {
     return JdtAnnotationUtils.findAnnotationBindingByName(
         packageBinding.getAnnotations(), JS_PACKAGE_ANNOTATION_NAME);
+  }
+
+  public static boolean isJsExport(IBinding typeBinding) {
+    return getJsExportAnnotation(typeBinding) != null;
   }
 
   public static boolean isJsPackageAnnotation(IAnnotationBinding annotation) {

--- a/transpiler/java/com/google/j2cl/transpiler/frontend/jdt/JsInteropUtils.java
+++ b/transpiler/java/com/google/j2cl/transpiler/frontend/jdt/JsInteropUtils.java
@@ -78,6 +78,7 @@ public final class JsInteropUtils {
             .setJsNamespace(JsInteropAnnotationUtils.getJsNamespace(memberAnnotation))
             .setJsOverlay(jsOverlay)
             .setJsAsync(jsAsync)
+            .setJsExport(publicMemberOfJsType && JsInteropAnnotationUtils.isJsExport(member))
             .setHasJsMemberAnnotation(memberAnnotation != null)
             .build();
       }


### PR DESCRIPTION
Annotating classes or methods with this annotation causes the symbol to be exported to other JavaScript code outside the control of j2cl, preventing them from being removed due to dead code pruning.

When a class is annotated, the result is equivalent to calling goog.exportSymbol with the qualified JavaScript name of the class.

When a method is annotated, the result is equivalent to annotating @export in the method's JsDoc comment.

This change only covers support for the jdt frontend and the closure backend.

The @JsExport annotation itself needs to be defined in a shared library. Currently, we expect it to have no parameters:

```java
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.METHOD, ElementType.TYPE})
public @interface JsExport {
}
```