### PR TITLE
Update Collections to support changes made in Java 9

### DIFF
--- a/jre/java/java/util/List.java
+++ b/jre/java/java/util/List.java
@@ -18,6 +18,7 @@ package java.util;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.util.function.UnaryOperator;
+import javaemul.internal.ArrayHelper;
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsNonNull;
@@ -32,6 +33,83 @@ import jsinterop.annotations.JsType;
  */
 @JsType
 public interface List<E> extends Collection<E> {
+
+  @JsIgnore
+  static <E> List<E> of() {
+    return Collections.unmodifiableList(Collections.emptyList());
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1) {
+    return __ofInternal((E[]) new Object[] {e1});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2) {
+    return __ofInternal((E[]) new Object[] {e1, e2});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
+  }
+
+  /**
+   * Internal-only helper to avoid copying the incoming array, and instead just wrap it with an
+   * immutable List after checking there are no nulls.
+   */
+  @JsIgnore
+  static <E> List<E> __ofInternal(E[] elements) {
+    for (int i = 0; i < elements.length; i++) {
+      checkNotNull(elements[i]);
+    }
+    return Collections.unmodifiableList(Arrays.asList(elements));
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E... elements) {
+    for (int i = 0; i < elements.length; i++) {
+      checkNotNull(elements[i]);
+    }
+    return Collections.unmodifiableList(
+            Arrays.asList((E[]) ArrayHelper.unsafeClone(elements, 0, elements.length))
+    );
+  }
 
   @JsMethod(name = "addAtIndex")
   void add(int index, E element);

--- a/jre/java/java/util/Map.java
+++ b/jre/java/java/util/Map.java
@@ -15,6 +15,7 @@
  */
 package java.util;
 
+import static javaemul.internal.InternalPreconditions.checkArgument;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.io.Serializable;
@@ -34,6 +35,211 @@ import jsinterop.annotations.JsType;
  */
 @JsType
 public interface Map<K, V> {
+
+  @JsIgnore
+  static <K, V> Map<K, V> of() {
+    return Collections.unmodifiableMap(Collections.emptyMap());
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(K key, V value) {
+    return ofEntries(
+            entry(key, value)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7,
+      K k8, V v8
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7),
+            entry(k8, v8)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7,
+      K k8, V v8,
+      K k9, V v9
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7),
+            entry(k8, v8),
+            entry(k9, v9)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7,
+      K k8, V v8,
+      K k9, V v9,
+      K k10, V v10
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7),
+            entry(k8, v8),
+            entry(k9, v9),
+            entry(k10, v10)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Entry<K, V> entry(K key, V value) {
+    // This isn't quite consistent with the javadoc, since this is serializable, while entry()
+    // need not be serializable.
+    return new AbstractMap.SimpleImmutableEntry<>(
+        checkNotNull(key),
+        checkNotNull(value)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> ofEntries(Entry<? extends K,? extends V>... entries) {
+    Map<K, V> map = new HashMap<>();
+
+    for (int i = 0; i < entries.length; i++) {
+      // TODO this perhaps can be optimized if we know the entry is an instance of
+      //  AbstractMap.SimpleImmutableEntry, or something more specialized?
+      Entry<? extends K, ? extends V> entry = checkNotNull(entries[i]);
+      checkArgument(map.put(checkNotNull(entry.getKey()), checkNotNull(entry.getValue())) == null,
+              "Can't add multiple entries with the same key");
+    }
+
+    return Collections.unmodifiableMap(map);
+  }
 
   /**
    * Represents an individual map entry.

--- a/jre/java/java/util/Set.java
+++ b/jre/java/java/util/Set.java
@@ -15,6 +15,9 @@
  */
 package java.util;
 
+import static javaemul.internal.InternalPreconditions.checkArgument;
+import static javaemul.internal.InternalPreconditions.checkNotNull;
+
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 
@@ -30,6 +33,70 @@ public interface Set<E> extends Collection<E> {
   @JsIgnore
   @Override
   Iterator<E> iterator();
+
+  @JsIgnore
+  static <E> Set<E> of() {
+    return Collections.unmodifiableSet(Collections.emptySet());
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1) {
+    return of((E[]) new Object[] {e1});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2) {
+    return of((E[]) new Object[] {e1, e2});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3) {
+    return of((E[]) new Object[] {e1, e2, e3});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4) {
+    return of((E[]) new Object[] {e1, e2, e3, e4});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E... elements) {
+    HashSet<E> set = new HashSet<>();
+    for (int i = 0; i < elements.length; i++) {
+      checkArgument(set.add(checkNotNull(elements[i])), "Can't add the same item multiple times");
+    }
+    return Collections.unmodifiableSet(set);
+  }
 
   @JsIgnore
   @Override

--- a/jre/javatests/BUILD
+++ b/jre/javatests/BUILD
@@ -125,6 +125,13 @@ j2cl_multi_test(
 )
 
 j2cl_multi_test(
+    name = "EmulJava9",
+    shard_count = 8,
+    test_class = "com.google.j2cl.jre.EmulJava9Suite",
+    deps = [":emul_tests_lib"],
+)
+
+j2cl_multi_test(
     name = "Lang",
     shard_count = 8,
     test_class = "com.google.j2cl.jre.LangSuite",

--- a/jre/javatests/com/google/j2cl/jre/EmulJava9Suite.java
+++ b/jre/javatests/com/google/j2cl/jre/EmulJava9Suite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Google Inc.
+ * Copyright 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,20 +15,19 @@
  */
 package com.google.j2cl.jre;
 
+import com.google.j2cl.jre.java9.util.ListTest;
+import com.google.j2cl.jre.java9.util.MapTest;
+import com.google.j2cl.jre.java9.util.SetTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-/** TestSuite for all of GWT's emul suites. */
+/** Test JRE emulations. */
 @RunWith(Suite.class)
 @SuiteClasses({
-  BigDecimalSuite.class,
-  BigIntegerSuite.class,
-  CollectionsSuite.class,
-  ConcurrentSuite.class,
-  EmulSuite.class,
-  EmulJava8Suite.class,
-  EmulJava9Suite.class,
-  LangSuite.class,
+        ListTest.class,
+        SetTest.class,
+        MapTest.class
 })
-public class AllTests {}
+public class EmulJava9Suite {
+}

--- a/jre/javatests/com/google/j2cl/jre/java/util/EmulTestBase.java
+++ b/jre/javatests/com/google/j2cl/jre/java/util/EmulTestBase.java
@@ -54,4 +54,22 @@ public class EmulTestBase extends TestCase {
         Arrays.equals(expected, actual));
   }
 
+  public static void assertNPE(String methodName, Runnable runnable) {
+    try {
+      runnable.run();
+      fail("Expected NPE from calling " + methodName);
+    } catch (NullPointerException ignored) {
+      // expected
+    }
+  }
+
+  public static void assertIAE(String methodName, Runnable runnable) {
+    try {
+      runnable.run();
+      fail("Expected IAE from calling " + methodName);
+    } catch (IllegalArgumentException ignored) {
+      // expected
+    }
+  }
+
 }

--- a/jre/javatests/com/google/j2cl/jre/java9/util/ListTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java9/util/ListTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.j2cl.jre.java9.util;
+
+import com.google.j2cl.jre.java.util.EmulTestBase;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Tests for java.util.List Java 9 API emulation.
+ */
+public class ListTest extends EmulTestBase {
+
+  public void testOf() {
+    assertIsImmutableListOf(List.of());
+    assertIsImmutableListOf(List.of("a"), "a");
+    assertIsImmutableListOf(
+        List.of("a", "b"),
+        "a", "b"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c"),
+        "a", "b", "c"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d"),
+        "a", "b", "c", "d"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e"),
+        "a", "b", "c", "d", "e"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f"),
+        "a", "b", "c", "d", "e", "f"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g"),
+        "a", "b", "c", "d", "e", "f", "g"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h"),
+        "a", "b", "c", "d", "e", "f", "g", "h"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"
+    );
+
+    // ensure that NPE is thrown if a value is null
+    assertNPE("of", () -> List.of((String) null));
+    assertNPE("of", () -> List.of("a", null));
+    assertNPE("of", () -> List.of("a", "b", null));
+    assertNPE("of", () -> List.of("a", "b", "c", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", null));
+  }
+
+  protected static void assertIsImmutableListOf(List<String> list, String... contents) {
+    assertEquals(contents, list);
+
+    // quick test that the list impl is sane
+    if (contents.length == 0) {
+      assertFalse(list.iterator().hasNext());
+    } else {
+      Iterator<String> itr = list.iterator();
+      assertTrue(itr.hasNext());
+      assertEquals(contents[0], itr.next());
+      assertEquals(contents.length > 1, itr.hasNext());
+    }
+
+    // quick check that the list is immutable
+    try {
+      list.add("another item");
+      fail("List should be unmodifiable: add(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    try {
+      list.remove(0);
+      fail("List should be unmodifiable: remove(int)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    // if any, remove an item actually in the list
+    if (contents.length > 0) {
+      // Without any items, remove(T) defaults to iterating items present, so we only test from
+      // present items
+      try {
+        list.remove(contents[0]);
+        fail("List should be unmodifiable: remove(T)");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+    }
+
+    // Remove an item that will not be in the list
+    try {
+      list.remove("not present");
+      fail("List should be unmodifiable: remove(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    try {
+      list.clear();
+      fail("List should be unmodifiable: clear()");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+  }
+}

--- a/jre/javatests/com/google/j2cl/jre/java9/util/MapTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java9/util/MapTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.j2cl.jre.java9.util;
+
+import com.google.j2cl.jre.java.util.EmulTestBase;
+
+import java.util.Map;
+
+/**
+ * Tests for java.util.Map Java 9 API emulation.
+ */
+public class MapTest extends EmulTestBase {
+
+  public void testOf() {
+    assertIsImmutableMapOf(Map.of());
+    assertIsImmutableMapOf(Map.of("a", 1), "a");
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2),
+        "a", "b"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3),
+        "a", "b", "c"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4),
+        "a", "b", "c", "d"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5),
+        "a", "b", "c", "d", "e"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6),
+        "a", "b", "c", "d", "e", "f"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7),
+        "a", "b", "c", "d", "e", "f", "g"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8),
+        "a", "b", "c", "d", "e", "f", "g", "h"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8, "i", 9),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8, "i", 9, "j", 10),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"
+    );
+
+    // ensure NullPointerException if either key or value are null for any param
+    assertNPE("Map.of(1)", () -> Map.of(null, 1));
+    assertNPE("Map.of(1)", () -> Map.of("a", null));
+    assertNPE("Map.of(2)", () -> Map.of("a", 1, null, 2));
+    assertNPE("Map.of(2)", () -> Map.of("a", 1, "b", null));
+    assertNPE("Map.of(3)", () -> Map.of("a", 1, "b", 2, null, 3));
+    assertNPE("Map.of(3)", () -> Map.of("a", 1, "b", 2, "c", null));
+    assertNPE("Map.of(4)", () -> Map.of("a", 1, "b", 2, "c", 3, null, 4));
+    assertNPE("Map.of(4)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", null));
+    assertNPE("Map.of(5)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, null, 5));
+    assertNPE("Map.of(5)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", null));
+    assertNPE("Map.of(6)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, null, 6));
+    assertNPE("Map.of(6)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", null));
+    assertNPE("Map.of(7)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        null, 7));
+    assertNPE("Map.of(7)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", null));
+    assertNPE("Map.of(8)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, null, 8));
+    assertNPE("Map.of(8)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", null));
+    assertNPE("Map.of(9)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, null, 9));
+    assertNPE("Map.of(9)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, "i", null));
+    assertNPE("Map.of(10)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, "i", 9, null, 10));
+    assertNPE("Map.of(10)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, "i", 9, "j", null));
+
+    // ensure IllegalArgumentException if any key is repeated
+    assertIAE("Map.of(2)", () -> Map.of("a", 1, "a", 2));
+    assertIAE("Map.of(3)", () -> Map.of("a", 1, "b", 2, "a", 3));
+    assertIAE("Map.of(4)", () -> Map.of("a", 1, "b", 2, "c", 3, "a", 4));
+    assertIAE("Map.of(5)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "a", 5));
+    assertIAE("Map.of(6)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "a", 6));
+    assertIAE("Map.of(7)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "a", 7));
+    assertIAE("Map.of(8)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7,
+        "a", 8));
+    assertIAE("Map.of(9)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7,
+        "h", 8, "a", 9));
+    assertIAE("Map.of(10)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7,
+        "h", 8, "i", 9, "a", 10));
+  }
+
+  protected static void assertIsImmutableMapOf(Map<String, Integer> map, String... contents) {
+    assertEquals(contents.length, map.size());
+    for (int i = 0; i < contents.length; i++) {
+      assertTrue(map.containsKey(contents[i]));
+      assertFalse(map.containsKey(contents[i] + "nope"));
+      assertEquals(i + 1, (int) map.get(contents[i]));
+    }
+
+    // quick check that the map is immutable
+    try {
+      map.put("another item", 1);
+      fail("Set should be unmodifiable: add(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    if (contents.length > 1) {
+      // Without any items, remove(T) defaults to iterating items present, so we only test from
+      // present items
+      try {
+        map.remove(contents[0]);
+        fail("Map should be unmodifiable: remove(T)");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+    }
+
+    try {
+      map.remove("not found");
+      fail("Map should be unmodifiable: remove(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    try {
+      map.clear();
+      fail("Set should be unmodifiable: clear()");
+    } catch (UnsupportedOperationException ignored) {
+      // expected
+    }
+  }
+
+  public void testEntry() {
+    Map.Entry<String, String> entry = Map.entry("a", "b");
+
+    assertEquals("a", entry.getKey());
+    assertEquals("b", entry.getValue());
+
+    try {
+      entry.setValue("z");
+      fail("Entry should be immutable: setValue");
+    } catch (UnsupportedOperationException ignore) {
+      // expected
+    }
+
+    assertNPE("Map.entry", () -> {
+      Map.entry(null, "value");
+    });
+    assertNPE("Map.entry", () -> {
+      Map.entry("key", null);
+    });
+  }
+
+  @SuppressWarnings("DuplicateMapKeys")
+  public void testOfEntries() {
+    Map<String, Integer> map = Map.ofEntries(
+        Map.entry("a", 1),
+        Map.entry("b", 2)
+    );
+
+    assertIsImmutableMapOf(map, "a", "b");
+
+    // ensure NullPointerException if any entry is null, if any key is null, or value is null
+    assertNPE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          null
+      );
+    });
+    assertNPE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry("c", null)
+      );
+    });
+    assertNPE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry(null, "d")
+      );
+    });
+
+    // ensure IllegalArgumentException if any pair has the same key (same or different value)
+    assertIAE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry("a", "b")
+      );
+    });
+    assertIAE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry("a", "c")
+      );
+    });
+  }
+}

--- a/jre/javatests/com/google/j2cl/jre/java9/util/SetTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java9/util/SetTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.j2cl.jre.java9.util;
+
+import com.google.j2cl.jre.java.util.EmulTestBase;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Tests for java.util.Set Java 9 API emulation.
+ */
+public class SetTest extends EmulTestBase {
+
+  public void testOf() {
+    assertIsImmutableSetOf(Set.of());
+    assertIsImmutableSetOf(Set.of("a"), "a");
+    assertIsImmutableSetOf(
+        Set.of("a", "b"),
+        "a", "b"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c"),
+        "a", "b", "c"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d"),
+        "a", "b", "c", "d"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e"),
+        "a", "b", "c", "d", "e"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f"),
+        "a", "b", "c", "d", "e", "f"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g"),
+        "a", "b", "c", "d", "e", "f", "g"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h"),
+        "a", "b", "c", "d", "e", "f", "g", "h"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"
+    );
+
+    // ensure NPE if any element is null
+    assertNPE("Set.of(1)", () -> Set.of((String) null));
+    assertNPE("Set.of(2)", () -> Set.of("a", null));
+    assertNPE("Set.of(3)", () -> Set.of("a", "b", null));
+    assertNPE("Set.of(4)", () -> Set.of("a", "b", "c", null));
+    assertNPE("Set.of(5)", () -> Set.of("a", "b", "c", "d", null));
+    assertNPE("Set.of(6)", () -> Set.of("a", "b", "c", "d", "e", null));
+    assertNPE("Set.of(7)", () -> Set.of("a", "b", "c", "d", "e", "f", null));
+    assertNPE("Set.of(8)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", null));
+    assertNPE("Set.of(9)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", null));
+    assertNPE("Set.of(10)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", null));
+    assertNPE("Set.of(...)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", null));
+
+    // ensure IAE if any element is duplicated
+    assertIAE("Set.of(2)", () -> Set.of("a", "a"));
+    assertIAE("Set.of(3)", () -> Set.of("a", "b", "a"));
+    assertIAE("Set.of(4)", () -> Set.of("a", "b", "c", "a"));
+    assertIAE("Set.of(5)", () -> Set.of("a", "b", "c", "d", "a"));
+    assertIAE("Set.of(6)", () -> Set.of("a", "b", "c", "d", "e", "a"));
+    assertIAE("Set.of(7)", () -> Set.of("a", "b", "c", "d", "e", "f", "a"));
+    assertIAE("Set.of(8)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "a"));
+    assertIAE("Set.of(9)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "a"));
+    assertIAE("Set.of(10)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "a"));
+    assertIAE("Set.of(...)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "a"));
+  }
+
+  protected static void assertIsImmutableSetOf(Set<String> set, String... contents) {
+    assertEquals(contents.length, set.size());
+    for (int i = 0; i < contents.length; i++) {
+      assertTrue(set.contains(contents[i]));
+      assertFalse(set.contains(contents[i] + "nope"));
+    }
+
+    // quick test that the set impl is sane, aside from the above
+    if (contents.length == 0) {
+      assertFalse(set.iterator().hasNext());
+    } else {
+      Iterator<String> itr = set.iterator();
+      assertTrue(itr.hasNext());
+
+      assertContains(contents, itr.next());
+
+      assertEquals(contents.length > 1, itr.hasNext());
+    }
+
+    // quick check that the set is immutable
+    try {
+      set.add("another item");
+      fail("Set should be unmodifiable: add(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    // if any, remove an item actually in the set
+    if (contents.length > 1) {
+      // Without any items, remove(T) defaults to iterating items present, so we only test from
+      // present items
+      try {
+        set.remove(contents[0]);
+        fail("Set should be unmodifiable: remove(T)");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+    }
+
+    // Remove an item that will not be in the set
+    try {
+      set.remove("not present");
+      fail("Set should be unmodifiable: remove(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    try {
+      set.clear();
+      fail("Set should be unmodifiable: clear()");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+  }
+
+  private static void assertContains(String[] contents, String value) {
+    for (String item : contents) {
+      if (item.equals(value)) {
+        return;
+      }
+    }
+    fail("Failed to find '" + value + "' in " + Arrays.toString(contents));
+  }
+}


### PR DESCRIPTION
See earlier review at https://gwt-review.googlesource.com/c/gwt/+/21501.

Build changes get us ready for missing Java 10 and 11 emulation as well.