### PR TITLE
Add Java 11 Optional.isEmpty()

### DIFF
--- a/jre/java/java/util/OptionalDouble.java
+++ b/jre/java/java/util/OptionalDouble.java
@@ -55,6 +55,10 @@ public final class OptionalDouble {
     return present;
   }
 
+  public boolean isEmpty() {
+    return !present;
+  }
+
   public double getAsDouble() {
     checkCriticalElement(present);
     return ref;

--- a/jre/java/java/util/OptionalInt.java
+++ b/jre/java/java/util/OptionalInt.java
@@ -55,6 +55,10 @@ public final class OptionalInt {
     return present;
   }
 
+  public boolean isEmpty() {
+    return !present;
+  }
+
   public int getAsInt() {
     checkCriticalElement(present);
     return ref;

--- a/jre/java/java/util/OptionalLong.java
+++ b/jre/java/java/util/OptionalLong.java
@@ -55,6 +55,10 @@ public final class OptionalLong {
     return present;
   }
 
+  public boolean isEmpty() {
+    return !present;
+  }
+
   public long getAsLong() {
     checkCriticalElement(present);
     return ref;

--- a/jre/javatests/com/google/j2cl/jre/java8/util/OptionalDoubleTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java8/util/OptionalDoubleTest.java
@@ -195,6 +195,11 @@ public class OptionalDoubleTest extends TestCase {
     assertEquals(REFERENCE, present.orElseThrow());
   }
 
+  public void testIsEmpty() {
+    assertTrue(empty.isEmpty());
+    assertFalse(present.isEmpty());
+  }
+
   public void testEquals() {
     // empty case
     assertFalse(empty.equals(null));

--- a/jre/javatests/com/google/j2cl/jre/java8/util/OptionalIntTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java8/util/OptionalIntTest.java
@@ -195,6 +195,11 @@ public class OptionalIntTest extends TestCase {
     assertEquals(REFERENCE, present.orElseThrow());
   }
 
+  public void testIsEmpty() {
+    assertTrue(empty.isEmpty());
+    assertFalse(present.isEmpty());
+  }
+
   public void testEquals() {
     // empty case
     assertFalse(empty.equals(null));

--- a/jre/javatests/com/google/j2cl/jre/java8/util/OptionalLongTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java8/util/OptionalLongTest.java
@@ -195,6 +195,11 @@ public class OptionalLongTest extends TestCase {
     assertEquals(REFERENCE, present.orElseThrow());
   }
 
+  public void testIsEmpty() {
+    assertTrue(empty.isEmpty());
+    assertFalse(present.isEmpty());
+  }
+
   public void testEquals() {
     // empty case
     assertFalse(empty.equals(null));

--- a/jre/javatests/com/google/j2cl/jre/java8/util/OptionalTest.java
+++ b/jre/javatests/com/google/j2cl/jre/java8/util/OptionalTest.java
@@ -56,8 +56,7 @@ public class OptionalTest extends TestCase {
     assertTrue(present.isPresent());
   }
 
-  // Disabled until Java 11 is enabled in Open source
-/*  public void testIsEmpty() {
+  public void testIsEmpty() {
     // empty case
     assertTrue(empty.isEmpty());
 
@@ -69,7 +68,7 @@ public class OptionalTest extends TestCase {
 
     present = Optional.ofNullable(REFERENCE);
     assertFalse(present.isEmpty());
-  }*/
+  }
 
   public void testGet() {
     // empty case


### PR DESCRIPTION
(cherry picked from commit d73d095eabcf18d565ee9eebacdaa2895ae77c52)

@gkdn 

- I have enabled com.google.j2cl.jre.java8.util.OptionalTest.testIsEmpty() coz j2cl is now support java11
- I also moved tests (Optional(Long/Int/Double) from java11 package to java8 to follow the same pattern as OptionalTest.testIsEmpty()

Please let me know if it's ok. 