### PR TITLE
Add 'not' method to Predicate.

### DIFF
--- a/jre/java/java/util/function/Predicate.java
+++ b/jre/java/java/util/function/Predicate.java
@@ -47,4 +47,9 @@ public interface Predicate<T> {
     checkCriticalNotNull(other);
     return t -> test(t) || other.test(t);
   }
+
+  @SuppressWarnings("unchecked")
+  static <T> Predicate<T> not(Predicate<? super T> other) {
+    return (Predicate<T>) other.negate();
+  }
 }


### PR DESCRIPTION
Add missing `not` method to Predicate to be java 11 compatible.

(cherry picked from commit c4befe7d0d402118f79be783d2cbcbb061054f04)