### PR TITLE
Fix guava sample WORKSPACE file

### DIFF
--- a/samples/guava/WORKSPACE
+++ b/samples/guava/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "com_google_j2cl_samples_helloworld")
+workspace(name = "com_google_j2cl_samples_guava")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 


### PR DESCRIPTION
The WORKSPACE file in the guava sample incorrectly builds the Hello World sample. Update the file to correctly build the guava project.

TEST: 
 - bazel build src/main/java/com/google/j2cl/samples/guava:guava
 - bazel build src/main/java/com/google/j2cl/samples/guava:guava-dev-server
 - navigate to http://localhost:6006/guava_dev.html