### PR TITLE
Run Github workflows with `-c opt`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,7 @@ jobs:
         run: |
           echo "build --repository_cache=~/bazel-repository-cache" >> ~/.bazelrc
           echo "build --disk_cache=~/bazel-action-cache" >> ~/.bazelrc
+          echo "build -c opt" >> ~/.bazelrc
           echo "build --verbose_failures" >> ~/.bazelrc
           bazel info
       - name: Run tests


### PR DESCRIPTION
This should shrink the action artifacts by quite a bit, hopefully buying us some headroom with the default Github runners, which are currently running out of disk space.

This will make compile times a bit longer (%5 on my M1 Pro), but this might be recovered by the smaller cache sizes. Currently transferring the action artifact cache takes about 1-1.5 minutes to download and about the same amount to upload.