### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Setup Java
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           java-version: '21'
           distribution: 'zulu'
@@ -61,7 +61,7 @@ jobs:
           ref: ${{ inputs.git_ref || github.ref }}
 
       - name: Cache Bazel repositories
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: ~/bazel-repository-cache
           key: bazel-repositories-${{hashFiles('**/MODULE.bazel')}}
@@ -69,7 +69,7 @@ jobs:
             bazel-repositories-
 
       - name: Cache Bazel results
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: ~/bazel-action-cache
           key: bazel-actions-${{runner.os}}-${{github.sha}}

--- a/.github/workflows/release_common.yaml
+++ b/.github/workflows/release_common.yaml
@@ -144,7 +144,7 @@ jobs:
 
       # Maven and Bazel require Java to be available.
       - name: Setup Java
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
           java-version: '21'
           distribution: 'zulu'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`9255dc7`](https://github.com/actions/cache/commit/9255dc7a253b0ccc959486e2bca901246202afeb) | [`8b402f5`](https://github.com/actions/cache/commit/8b402f58fbc84540c8b491a91e594a4576fec3d7) | [Release](https://github.com/actions/cache/releases/tag/v5) | ci.yaml |
| `actions/setup-java` | [`f2beeb2`](https://github.com/actions/setup-java/commit/f2beeb24e141e01a676f977032f5a29d81c9e27e) | [`be666c2`](https://github.com/actions/setup-java/commit/be666c2fcd27ec809703dec50e508c2fdc7f6654) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | ci.yaml, release_common.yaml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
