### PR TITLE
Use strict equality in code

### DIFF
--- a/jre/java/javaemul/internal/nativebootstrap/Equality.impl.java.js
+++ b/jre/java/javaemul/internal/nativebootstrap/Equality.impl.java.js
@@ -41,7 +41,7 @@ class Equality {
    * @return {boolean}
    */
   static $sameNumber(left, right) {
-    return left == right;
+    return left === right;
   }
 }
 


### PR DESCRIPTION
The code around line 44 in jre/java/javaemul/internal/nativebootstrap/Equality.impl.java.js looked like it might have an issue. The loose equality here can coerce values in ways that are hard to spot later. this patch tightens it to strict equality.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.