### PR TITLE
Fixes for bazel 9

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_repo.bzl
+++ b/build_defs/internal_do_not_use/j2cl_repo.bzl
@@ -29,7 +29,7 @@ def _j2cl_maven_import_external(repository_ctx):
     coordinates = _decode_maven_coordinates(repository_ctx.attr.artifact, default_packaging = "jar")
     artifact_urls = _convert_coordinates_to_urls(coordinates, repository_ctx.attr.server_urls)
     additional_attrs = dict(repository_ctx.attr.additional_rule_attrs)
-    additional_attrs["tags"] = repository_ctx.attr.tags + [
+    additional_attrs["tags"] = getattr(repository_ctx.attr, "tags", []) + [
         "maven_coordinates=" + repository_ctx.attr.artifact,
     ]
 
@@ -39,6 +39,7 @@ def _j2cl_maven_import_external(repository_ctx):
 def _j2cl_import_external_common(repository_ctx, artifact_urls, additional_attrs):
     lines = [
         "load('@j2cl//build_defs:rules.bzl', 'j2cl_library', 'j2cl_import')",
+        "load('@rules_java//java:defs.bzl', 'java_import')",
         "",
         "package(default_visibility = %s)" % repository_ctx.attr.default_visibility,
         "",

--- a/tools/java/com/google/j2cl/tools/rta/BUILD
+++ b/tools/java/com/google/j2cl/tools/rta/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #  Implementation of RTA algorithm used to do fast method pruning.
 
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load("//transpiler/java/com/google/j2cl/common/bazel:jvm_flags.bzl", "JVM_FLAGS")
 

--- a/tools/javatests/com/google/j2cl/tools/rta/proto/BUILD
+++ b/tools/javatests/com/google/j2cl/tools/rta/proto/BUILD
@@ -1,3 +1,4 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//third_party/java/j2cl_proto:j2cl_proto_library.bzl", "j2cl_proto_library")
 load(
     "//tools/javatests/com/google/j2cl/tools/rta:rta_test.bzl",

--- a/transpiler/java/com/google/j2cl/transpiler/backend/kotlin/BUILD.bazel
+++ b/transpiler/java/com/google/j2cl/transpiler/backend/kotlin/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_applicable_licenses = ["//:j2cl_license"],
     default_visibility = ["//transpiler:__subpackages__"],

--- a/transpiler/java/com/google/j2cl/transpiler/backend/libraryinfo/BUILD
+++ b/transpiler/java/com/google/j2cl/transpiler/backend/libraryinfo/BUILD
@@ -1,3 +1,5 @@
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_library")
 
 package(

--- a/transpiler/java/com/google/j2cl/transpiler/backend/wasm/BUILD
+++ b/transpiler/java/com/google/j2cl/transpiler/backend/wasm/BUILD
@@ -1,3 +1,5 @@
+load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_library")
 
 package(


### PR DESCRIPTION
Moslty add import rules for @protobuf and @rules_java. I'm not sure why the `.tags` broke when upgrading to bazel 9 but you can see precedent for the `getattr` style here (as `hasattr`): https://github.com/bazelbuild/bazel/blob/66f385645e351a55415b4ae341d6cd2e7ab6d4e4/tools/compliance/gather_packages.bzl#L167