### PR TITLE
docs: fix typos overriden -> overridden, noticable -> noticeable

### DIFF
--- a/docs/design/records-jsinterop.md
+++ b/docs/design/records-jsinterop.md
@@ -66,7 +66,7 @@ When a Java Record is annotated with `@JsType`:
         `@JsMethod` (e.g., `instance.myCustomMethod()`).
     *   The compiler-generated `equals()`, `hashCode()`, and `toString()`
         methods will be exposed implicitly to JavaScript, consistent with
-        overriden methods from `java.lang.Object`.
+        overridden methods from `java.lang.Object`.
     *   Public static methods within the record body will be exposed.
 4.  **Fields:** Records can define static fields which will be exposed following
     regular JsType semantics.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -30,7 +30,7 @@ Instead JavaScript `number` is used to emulate `float` without any
 instrumentation and results in 64 bit precision. This makes them effectively
 same as the `double` type in Java.
 
-This is rarely noticable in practice but if for your application repeatability
+This is rarely noticeable in practice but if for your application repeatability
 of the floating point arithmetic really matters across different platforms, this
 is something to keep in mind.
 


### PR DESCRIPTION
Two typo fixes:

- `docs/design/records-jsinterop.md:69` — `overriden` → `overridden`
- `docs/limitations.md:33` — `noticable` → `noticeable`

Docs only.
